### PR TITLE
Reset previous audio session category on onCancel

### DIFF
--- a/ios/Classes/SwiftMicStreamPlugin.swift
+++ b/ios/Classes/SwiftMicStreamPlugin.swift
@@ -28,6 +28,8 @@ public class SwiftMicStreamPlugin: NSObject, FlutterStreamHandler, FlutterPlugin
     var session : AVCaptureSession!
     var audioSession: AVAudioSession!
     var oldAudioSessionCategory: AVAudioSession.Category?
+    var oldAudioSessionMode: AVAudioSession.Mode?
+    var oldAudioSessionPolicy: AVAudioSession.RouteSharingPolicy?
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
@@ -40,6 +42,9 @@ public class SwiftMicStreamPlugin: NSObject, FlutterStreamHandler, FlutterPlugin
             case "getBufferSize":
                 result(Int(self.audioSession.ioBufferDuration*self.audioSession.sampleRate))//calculate the true buffer size
                 break;
+            case "clean":
+                onCancel(withArguments: nil)
+                break;
             default:
                 result(FlutterMethodNotImplemented)
         }
@@ -48,55 +53,47 @@ public class SwiftMicStreamPlugin: NSObject, FlutterStreamHandler, FlutterPlugin
     public func onCancel(withArguments arguments:Any?) -> FlutterError?  {
         self.session?.stopRunning()
         if let category = oldAudioSessionCategory {
-            try? audioSession.setCategory(category)
+            try! audioSession.setCategory(category, mode: oldAudioSessionMode!, policy: oldAudioSessionPolicy!, options: oldAudioSessionCategoryOptions!)
         }
         return nil
     }
 
     public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
-        
         if (isRecording) {
             return nil;
         }
     
-        let config = arguments as! [Int?];
-        // Set parameters, if available
-        //print("this is config: \(config)")
+        let config = arguments as! [Int?]
         switch config.count {
             case 4:
                 AUDIO_FORMAT = AudioFormat(rawValue:config[3]!)!;
                 if(AUDIO_FORMAT != AudioFormat.ENCODING_PCM_16BIT) {
-                    events(FlutterError(code: "-3",
-                                                          message: "Currently only AudioFormat ENCODING_PCM_16BIT is supported", details:nil))
+                    events(FlutterError(code: "-3", message: "Currently only AudioFormat ENCODING_PCM_16BIT is supported", details:nil))
                     return nil
                 }
                 fallthrough
             case 3:
                 CHANNEL_CONFIG = ChannelConfig(rawValue:config[2]!)!;
                 if(CHANNEL_CONFIG != ChannelConfig.CHANNEL_IN_MONO) {
-                    events(FlutterError(code: "-3",
-                                                          message: "Currently only ChannelConfig CHANNEL_IN_MONO is supported", details:nil))
+                    events(FlutterError(code: "-3", message: "Currently only ChannelConfig CHANNEL_IN_MONO is supported", details:nil))
                     return nil
                 }
                 fallthrough
             case 2:
                 SAMPLE_RATE = config[1]!;
                 if(SAMPLE_RATE<8000 || SAMPLE_RATE>48000) {
-                    events(FlutterError(code: "-3",
-                                                          message: "iPhone only sample rates between 8000 and 48000 are supported", details:nil))
+                    events(FlutterError(code: "-3", message: "iPhone only sample rates between 8000 and 48000 are supported", details:nil))
                     return nil
                 }
                 fallthrough
             case 1:
                 AUDIO_SOURCE = AudioSource(rawValue:config[0]!)!;
                 if(AUDIO_SOURCE != AudioSource.DEFAULT) {
-                    events(FlutterError(code: "-3",
-                                        message: "Currently only default AUDIO_SOURCE (id: 0) is supported", details:nil))
+                    events(FlutterError(code: "-3", message: "Currently only default AUDIO_SOURCE (id: 0) is supported", details:nil))
                     return nil
                 }
             default:
-                events(FlutterError(code: "-3",
-                                  message: "At least one argument (AudioSource) must be provided ", details:nil))
+                events(FlutterError(code: "-3", message: "At least one argument (AudioSource) must be provided ", details:nil))
                 return nil
         }
         self.eventSink = events;
@@ -109,7 +106,7 @@ public class SwiftMicStreamPlugin: NSObject, FlutterStreamHandler, FlutterPlugin
         if let audioCaptureDevice : AVCaptureDevice = AVCaptureDevice.default(for:AVMediaType.audio) {
 
             self.session = AVCaptureSession()
-            self.audioSession=AVAudioSession.sharedInstance()
+            self.audioSession = AVAudioSession.sharedInstance()
             do {
                 //magic word
                 //This will allow developers to specify sample rates, etc.
@@ -118,6 +115,9 @@ public class SwiftMicStreamPlugin: NSObject, FlutterStreamHandler, FlutterPlugin
                 try audioCaptureDevice.lockForConfiguration()
 
                 oldAudioSessionCategory = audioSession.category
+                oldAudioSessionCategoryOptions = audioSession.categoryOptions
+                oldAudioSessionMode = audioSession.mode
+                oldAudioSessionPolicy = audioSession.routeSharingPolicy
                 
                 try audioSession.setCategory(AVAudioSession.Category.record,mode: .measurement)
 
@@ -169,8 +169,7 @@ public class SwiftMicStreamPlugin: NSObject, FlutterStreamHandler, FlutterPlugin
                 // print("Error encountered starting audio capture, see details for more information.")
                 // print(e)
                 
-                self.eventSink!(FlutterError(code: "-3",
-                             message: "Error encountered starting audio capture, see details for more information.", details:e))
+                self.eventSink!(FlutterError(code: "-3", message: "Error encountered starting audio capture, see details for more information.", details:e))
             }
         }
     }
@@ -211,6 +210,5 @@ public class SwiftMicStreamPlugin: NSObject, FlutterStreamHandler, FlutterPlugin
         let data = Data(bytesNoCopy: audioBufferList.mBuffers.mData!, count: Int(audioBufferList.mBuffers.mDataByteSize), deallocator: .none)
         
         self.eventSink!(FlutterStandardTypedData(bytes: data))
-
     }
 }

--- a/ios/Classes/SwiftMicStreamPlugin.swift
+++ b/ios/Classes/SwiftMicStreamPlugin.swift
@@ -27,6 +27,7 @@ public class SwiftMicStreamPlugin: NSObject, FlutterStreamHandler, FlutterPlugin
     var eventSink:FlutterEventSink?;
     var session : AVCaptureSession!
     var audioSession: AVAudioSession!
+    var oldAudioSessionCategory: AVAudioSession.Category?
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
@@ -46,6 +47,9 @@ public class SwiftMicStreamPlugin: NSObject, FlutterStreamHandler, FlutterPlugin
     
     public func onCancel(withArguments arguments:Any?) -> FlutterError?  {
         self.session?.stopRunning()
+        if let category = oldAudioSessionCategory {
+            try? audioSession.setCategory(category)
+        }
         return nil
     }
 
@@ -113,6 +117,8 @@ public class SwiftMicStreamPlugin: NSObject, FlutterStreamHandler, FlutterPlugin
                 
                 try audioCaptureDevice.lockForConfiguration()
 
+                oldAudioSessionCategory = audioSession.category
+                
                 try audioSession.setCategory(AVAudioSession.Category.record,mode: .measurement)
 
                 try audioSession.setPreferredSampleRate(Double(SAMPLE_RATE))

--- a/lib/mic_stream.dart
+++ b/lib/mic_stream.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:permission_handler/permission_handler.dart' as handler;
 import 'package:flutter/services.dart';
+import 'package:permission_handler/permission_handler.dart' as handler;
 
 // In reference to the implementation of the official sensors plugin
 // https://github.com/flutter/plugins/tree/master/packages/sensors
@@ -35,18 +35,15 @@ class MicStream {
   static bool _requestPermission = true;
 
   static const AudioSource DEFAULT_AUDIO_SOURCE = AudioSource.DEFAULT;
-  static const ChannelConfig DEFAULT_CHANNELS_CONFIG =
-      ChannelConfig.CHANNEL_IN_MONO;
+  static const ChannelConfig DEFAULT_CHANNELS_CONFIG = ChannelConfig.CHANNEL_IN_MONO;
   static const AudioFormat DEFAULT_AUDIO_FORMAT = AudioFormat.ENCODING_PCM_8BIT;
   static const int DEFAULT_SAMPLE_RATE = 16000;
 
   static const int _MIN_SAMPLE_RATE = 1;
   static const int _MAX_SAMPLE_RATE = 100000;
 
-  static const EventChannel _microphoneEventChannel =
-      EventChannel('aaron.code.com/mic_stream');
-  static const MethodChannel _microphoneMethodChannel =
-      MethodChannel('aaron.code.com/mic_stream_method_channel');
+  static const EventChannel _microphoneEventChannel = EventChannel('aaron.code.com/mic_stream');
+  static const MethodChannel _microphoneMethodChannel = MethodChannel('aaron.code.com/mic_stream_method_channel');
 
   /// The actual sample rate used for streaming.  This may return zero if invoked without listening to the _microphone Stream
   static Future<double>? get sampleRate => _sampleRate;
@@ -91,10 +88,7 @@ class MicStream {
   /// audioFormat:     Switch between 8- and 16-bit PCM streams
   ///
   static Future<Stream<Uint8List>?> microphone(
-      {AudioSource? audioSource,
-      int? sampleRate,
-      ChannelConfig? channelConfig,
-      AudioFormat? audioFormat}) async {
+      {AudioSource? audioSource, int? sampleRate, ChannelConfig? channelConfig, AudioFormat? audioFormat}) async {
     audioSource ??= DEFAULT_AUDIO_SOURCE;
     sampleRate ??= DEFAULT_SAMPLE_RATE;
     channelConfig ??= DEFAULT_CHANNELS_CONFIG;
@@ -102,8 +96,7 @@ class MicStream {
 
     if (sampleRate < _MIN_SAMPLE_RATE || sampleRate > _MAX_SAMPLE_RATE)
       throw (RangeError.range(sampleRate, _MIN_SAMPLE_RATE, _MAX_SAMPLE_RATE));
-    if (_requestPermission) if (!(await permissionStatus))
-      throw (PlatformException);
+    if (_requestPermission) if (!(await permissionStatus)) throw (PlatformException);
 
     // If first time or configs have changed reinitialise audio recorder
     if (audioSource != __audioSource ||
@@ -137,15 +130,16 @@ class MicStream {
     listener = _microphone!.listen((x) async {
       await listener!.cancel();
       listener = null;
-      sampleRateCompleter.complete(await _microphoneMethodChannel
-          .invokeMethod("getSampleRate") as double?);
-      bitDepthCompleter.complete(
-          await _microphoneMethodChannel.invokeMethod("getBitDepth") as int?);
-      bufferSizeCompleter.complete(
-          await _microphoneMethodChannel.invokeMethod("getBufferSize") as int?);
+      sampleRateCompleter.complete(await _microphoneMethodChannel.invokeMethod("getSampleRate") as double?);
+      bitDepthCompleter.complete(await _microphoneMethodChannel.invokeMethod("getBitDepth") as int?);
+      bufferSizeCompleter.complete(await _microphoneMethodChannel.invokeMethod("getBufferSize") as int?);
     });
 
     return _microphone;
+  }
+
+  static void clean() {
+    _microphoneMethodChannel.invokeMethod("clean");
   }
 
   /// Updates flag to determine whether to request audio recording permission. Set to false to disable dialogue, set to true (default) to request permission if necessary


### PR DESCRIPTION
Into startCapture method, there is an override of audioSession category but the previous category wasn't set after stopping the session