### PR TITLE
Turn microphone into a broadcast stream

### DIFF
--- a/lib/mic_stream.dart
+++ b/lib/mic_stream.dart
@@ -142,9 +142,10 @@ class MicStream {
       return Stream.error(
           RangeError.range(sampleRate, _MIN_SAMPLE_RATE, _MAX_SAMPLE_RATE));
 
-    final permissionStatus = _requestPermission
-        ? Stream.fromFuture(MicStream.permissionStatus)
-        : Stream.value(true);
+    final permissionStatus = (_requestPermission
+            ? Stream.fromFuture(MicStream.permissionStatus)
+            : Stream.value(true))
+        .asBroadcastStream();
 
     return permissionStatus.asyncExpand((grantedPermission) {
       if (!grantedPermission) {


### PR DESCRIPTION
The microphone is naturally a broadcast stream. However, the public stream is a sequence of `permissionStatus` and `_microphone` events using [`asyncExpand`](https://api.flutter.dev/flutter/dart-async/Stream/asyncExpand.html).

`asyncExpand` has a peculiar behavior:
> The returned stream is a broadcast stream if this stream is.

Before this PR, the returned stream is single-subscription even if `_microphone` is a broadcast stream. The problem with a single-subscription stream with the new (> `0.7.0`) mic_stream API is described in #69.